### PR TITLE
fix: avoid tags squeezing with inline code

### DIFF
--- a/sass/_common.sass
+++ b/sass/_common.sass
@@ -115,7 +115,7 @@ table
 
 // tag
 a.tag
-  padding: 0.1em 0.5em
+  padding: 0 0.5em
   background-color: var(--accent-fg)
   color: #fff !important
   border-radius: 2em


### PR DESCRIPTION
If a tag is above the inline code block, they will squeeze with each other, just like below:

<img width="313" alt="image" src="https://user-images.githubusercontent.com/3401641/186835300-8a67ad17-cdb5-411f-8e9e-8660b815b033.png">
